### PR TITLE
Emaggable Clean and Floor Bots

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 822779961239697815}
   - component: {fileID: -8380667346639020303}
   - component: {fileID: 6801814165055322343}
+  - component: {fileID: -3116353301156381755}
   m_Layer: 12
   m_Name: Cleanbot
   m_TagString: Untagged
@@ -83,7 +84,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -177,6 +184,7 @@ MonoBehaviour:
   actionPerformTime: 3
   hasFoodPrefereces: 0
   foodPreferences: []
+  isEmagged: 0
 --- !u!114 &822779961239697815
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -253,6 +261,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &-3116353301156381755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5037153879944481302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteRenderer: {fileID: 7911763529354618204}
+  emaggedSprite: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
 --- !u!1 &6180971314615384560
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &7031484669288739102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6390563642695955054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteRenderer: {fileID: 8107741572011646244}
+  emaggedSprite: {fileID: 21300000, guid: bd95a76ea5bef07478a4a984d8605672, type: 3}
 --- !u!1001 &2110014500151851128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24,6 +40,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -39,6 +60,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -51,16 +77,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
@@ -88,5 +104,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3093160451266126740, guid: d546bfef3536f9342894606705d01a9e,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -3116353301156381755, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
+--- !u!1 &6390563642695955054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5037153879944481302, guid: 52e52506ef7e83e41a024f96fadc9304,
+    type: 3}
+  m_PrefabInstance: {fileID: 2110014500151851128}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &8107741572011646244 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 7911763529354618204, guid: 52e52506ef7e83e41a024f96fadc9304,
+    type: 3}
+  m_PrefabInstance: {fileID: 2110014500151851128}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 5455455252294224591}
   - component: {fileID: 7304802151653684397}
   - component: {fileID: 9084638841217414174}
+  - component: {fileID: 5579325328306395513}
   m_Layer: 12
   m_Name: Floorbot
   m_TagString: Untagged
@@ -83,7 +84,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -108,6 +115,8 @@ MonoBehaviour:
   objectType: 0
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &5133121035479701040
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -122,6 +131,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &2008208207829246944
 MonoBehaviour:
@@ -163,8 +173,18 @@ MonoBehaviour:
   performingAction: 0
   activated: 1
   tickRate: 1
+  EatFoodA:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   target: 2
   actionPerformTime: 3
+  hasFoodPrefereces: 0
+  foodPreferences: []
+  isEmagged: 0
 --- !u!114 &5455455252294224591
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -177,8 +197,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &7304802151653684397
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,7 +220,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -214,7 +249,6 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
 --- !u!114 &9084638841217414174
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,9 +261,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5579325328306395513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2293724657804988958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  forceHidden: 0
+  spriteRenderer: {fileID: 4443060873987540845}
+  emaggedSprite: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
 --- !u!1 &4825667868636187068
 GameObject:
   m_ObjectHideFlags: 0
@@ -276,6 +323,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -298,7 +346,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 15
+  m_SortingLayer: 21
   m_SortingOrder: 11
   m_Sprite: {fileID: 21300000, guid: fbef0531e2d0c404eb39646b93b4d746, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using UnityEngine;
+using Mirror;
+using Systems.MobAIs;
+
+public class InteractableBot : NetworkBehaviour, IPredictedCheckedInteractable<HandApply>
+{
+	HandApply interaction;
+	public SpriteRenderer spriteRenderer;
+	public Sprite emaggedSprite;
+
+	private MobExplore mobController;
+	public MobExplore MobController
+	{
+		get
+		{
+			if (!mobController)
+			{
+				mobController = GetComponent<MobExplore>();
+			}
+			return mobController;
+		}
+	}
+	public void ClientPredictInteraction(HandApply interaction) { }
+
+	public void ServerRollbackClient(HandApply interaction) { }
+
+	public bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		if (!DefaultWillInteract.Default(interaction, side)) return false;
+		if (interaction.TargetObject != gameObject) return false;
+		if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
+
+		return MobController != null;
+	}
+	public void ServerPerformInteraction(HandApply interaction)
+	{
+		this.interaction = interaction;
+
+		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
+			&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
+			&& emag.EmagHasCharges())
+		{
+			TryEmag(emag, interaction);
+		}		
+	}
+	public void TryEmag(Emag emag, HandApply interaction)
+	{
+		if (MobController == null) return;
+		MobController.isEmagged = true;
+		if(emaggedSprite != null && spriteRenderer != null) spriteRenderer.sprite = emaggedSprite;
+		emag.UseCharge(interaction);
+	}
+}


### PR DESCRIPTION
Allows for traitors to emag floor and clean bots. Emagging the bots gives a small visual change and changes the bots AI. Floorbots will rip up floor tiles and Cleanbots will begin cleaning every tile in sight, creating messes of wet floor wherever they go. (Also includes a minor bug fix for floorbots)

